### PR TITLE
reduce docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,48 +3,47 @@ FROM phusion/baseimage:0.11
 LABEL maintainer="doitandbedone"
 
 # Add universe repo
-RUN add-apt-repository universe && \
-apt-get update
+RUN add-apt-repository universe \
+  && apt-get update \
 
-# Install wget
-RUN apt-get install -y wget
+  # Install wget and unzip:
+  && apt-get install -y --no-install-recommends wget unzip \
 
-# Install .NET core:
-# Add MS repo key and feed
-RUN wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb && \
-dpkg -i packages-microsoft-prod.deb
+  # Install .NET core:
+  # Add MS repo key and feed
+  && wget https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb \
+  && dpkg -i packages-microsoft-prod.deb \
 
-# Install .NET Core SDK
-RUN apt-get install -y apt-transport-https && \
-apt-get update && \
-apt-get install -y dotnet-sdk-3.1
+  # Install .NET Core SDK
+  && apt-get install -y --no-install-recommends apt-transport-https \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends dotnet-sdk-3.1 \
 
-# Install ASP .NET Core runtime
-RUN apt-get install -y apt-transport-https && \
-apt-get update && \
-apt-get install -y aspnetcore-runtime-3.1
+  # Install ASP .NET Core runtime
+  && apt-get install -y --no-install-recommends apt-transport-https \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends aspnetcore-runtime-3.1 \
 
-# Install .NET Core runtime
-RUN apt-get install -y apt-transport-https && \
-apt-get update && \
-apt-get install -y dotnet-runtime-3.1
+  # Install .NET Core runtime
+  && apt-get install -y --no-install-recommends apt-transport-https \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends dotnet-runtime-3.1 \
 
-# Install FFmpeg v4.x:
-RUN add-apt-repository ppa:jonathonf/ffmpeg-4 && \
-apt-get update && \
-apt-get install -y ffmpeg
+  # Install FFmpeg v4.x:
+  && add-apt-repository ppa:jonathonf/ffmpeg-4 \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends ffmpeg \
 
-# Install libtbb and libc6 (Optional)
-RUN apt-get install -y libtbb-dev && \
-apt-get install -y libc6-dev
+  # Install libtbb and libc6 (Optional)
+  && apt-get install -y --no-install-recommends libtbb-dev \
+  && apt-get install -y --no-install-recommends libc6-dev \
 
-# Install unzip:
-RUN apt-get install -y unzip
-
-# Download/Install iSpy Agent DVR (latest version):
-RUN wget -c $(wget -qO- "https://www.ispyconnect.com/api/Agent/DownloadLocation2?productID=24&is64=true&platform=Linux" | tr -d '"') -O agent.zip && \
-unzip agent.zip -d /agent && \
-rm agent.zip
+  # Download/Install iSpy Agent DVR (latest version):
+  && wget -c $(wget -qO- "https://www.ispyconnect.com/api/Agent/DownloadLocation2?productID=24&is64=true&platform=Linux" | tr -d '"') -O agent.zip \
+  && unzip agent.zip -d /agent \
+  && rm agent.zip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Main UI port
 EXPOSE 8090


### PR DESCRIPTION
Add `--no-install-recommends` to all apt-install commands to prevent installation of unnecessary pachages.

Combine all run commands into a single command to allow for cleanup after installation (combines them into a single layer).

Added  `apt-get clean` and `rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*` to the end of the installation to cleanup installation files.

This reduces the image file from ~367MB to ~322MB.

Alternatively, the cleanup commands could be added to the end of each installation step to keep separate layers during installation.