### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,20 @@ RUN wget -c $(wget -qO- "https://www.ispyconnect.com/api/Agent/DownloadLocation2
 unzip agent.zip -d /agent && \
 rm agent.zip
 
+# Docker needs to run a TURN server to get webrtc traffic to and from it over forwarded ports from the host
+# These are the default ports. If the ports below are modified here you'll also need to set the ports in XML/Config.xml
+# for example <TurnServerPort>3478</TurnServerPort><TurnServerMinPort>50000</TurnServerMinPort><TurnServerMaxPort>50010</TurnServerMaxPort>
+# The main server port is overridden by creating a text file called port.txt in the root directory containing the port number, eg: 8090
+# To access the UI you must use the local IP address of the host, NOT localhost - for example http://192.168.1.12:8090/
+
 # Main UI port
 EXPOSE 8090
+
+# TURN server port
+EXPOSE 3478/udp
+
+# TURN server UDP port range
+EXPOSE 50000-50010/udp
 
 # Data volumes
 VOLUME ["/agent/Media/XML", "/agent/Media/WebServerRoot/Media"]


### PR DESCRIPTION
Adds ports for TURN server integration (v2.8.4.0+)
important:
To access the UI you must use the local IP address of the host, NOT localhost - for example http://192.168.1.12:8090/

example to run docker:

docker run -p 8090:8090 -p 3478:3478/udp -p 50000-50010:50000-50010/udp --name agent agent:1.0