### PR TITLE
Add arm32v7 and arm64v8 Dockerfiles

### DIFF
--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,5 +1,6 @@
 # Use MS maintained .net docker image wuith aspnet and core runtimes.
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.17-focal-arm32v7
+# switching to buster for GLIBC 2.28, required by libcvextern.so from AgentDVR latest
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.17-buster-slim-arm32v7
 
 #Define download location variables
 ARG FILE_LOCATION="https://ispyfiles.azureedge.net/downloads/Agent_ARM32_3_4_3_0.zip"
@@ -11,7 +12,7 @@ ARG TZ=America/Los_Angeles
 
 # Download and install dependencies
 RUN apt-get update \
-    && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common libatlas-base-dev \
+    && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common libatlas-base-dev gpg ffmpeg \
     && wget http://ports.ubuntu.com/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \
     && wget http://ports.ubuntu.com/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_armhf.deb \
     && dpkg -i libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \
@@ -20,8 +21,8 @@ RUN apt-get update \
     && rm libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb
 
 # Install jonathon's ffmpeg
-RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
-    apt-get update && apt-get install -y ffmpeg
+#RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
+#    apt-get update && apt-get install -y ffmpeg
 
 # Download/Install iSpy Agent DVR: 
 # Check if we were given a specific version

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,5 +1,5 @@
 # Use MS maintained .net docker image wuith aspnet and core runtimes.
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.10-bionic-arm32v7
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.17-bionic-arm32v7
 
 #Define download location variables
 ARG FILE_LOCATION="https://ispyfiles.azureedge.net/downloads/Agent_ARM32_3_4_3_0.zip"

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -11,7 +11,7 @@ ARG TZ=America/Los_Angeles
 
 # Download and install dependencies
 RUN apt-get update \
-    && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common \
+    && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common libatlas-base-dev \
     && wget http://ports.ubuntu.com/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \
     && wget http://ports.ubuntu.com/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_armhf.deb \
     && dpkg -i libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -12,8 +12,8 @@ ARG TZ=America/Los_Angeles
 # Download and install dependencies
 RUN apt-get update \
     && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common \
-    && wget http://security.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \
-    && wget http://fr.archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_armhf.deb \
+    && wget http://ports.ubuntu.com/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \
+    && wget http://ports.ubuntu.com/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_armhf.deb \
     && dpkg -i libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \
     && dpkg -i libjpeg8_8c-2ubuntu8_armhf.deb \
     && rm libjpeg8_8c-2ubuntu8_armhf.deb \

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,0 +1,73 @@
+# Use MS maintained .net docker image wuith aspnet and core runtimes.
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.10-bionic-arm32v7
+
+#Define download location variables
+ARG FILE_LOCATION="https://ispyfiles.azureedge.net/downloads/Agent_ARM32_3_4_3_0.zip"
+ENV FILE_LOCATION_SET=${FILE_LOCATION:+true}
+ENV DEFAULT_FILE_LOCATION="https://www.ispyconnect.com/api/Agent/DownloadLocation2?productID=24&is64=true&platform=Linux"
+ARG DEBIAN_FRONTEND=noninteractive 
+ARG TZ=America/Los_Angeles
+    
+
+# Download and install dependencies
+RUN apt-get update \
+    && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common \
+    && wget http://security.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \
+    && wget http://fr.archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_armhf.deb \
+    && dpkg -i libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb \
+    && dpkg -i libjpeg8_8c-2ubuntu8_armhf.deb \
+    && rm libjpeg8_8c-2ubuntu8_armhf.deb \
+    && rm libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_armhf.deb
+
+# Install jonathon's ffmpeg
+RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
+    apt-get update && apt-get install -y ffmpeg
+
+# Download/Install iSpy Agent DVR: 
+# Check if we were given a specific version
+RUN if [ "${FILE_LOCATION_SET}" = "true" ]; then \
+    echo "Downloading from specific location: ${FILE_LOCATION}" && \
+    wget -c ${FILE_LOCATION} -O agent.zip; \
+    else \
+    #Get latest instead
+    echo "Downloading latest" && \
+    wget -c $(wget -qO- "https://www.ispyconnect.com/api/Agent/DownloadLocation2?productID=24&is64=true&platform=Linux" | tr -d '"') -O agent.zip; \
+    fi && \
+    unzip agent.zip -d /agent && \
+    rm agent.zip
+    
+# Install libgdiplus, used for smart detection
+RUN apt-get install -y libgdiplus
+    
+# Install Time Zone
+RUN apt-get install -y tzdata
+
+# Clean up
+RUN apt-get -y --purge remove unzip wget \ 
+    && apt autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker needs to run a TURN server to get webrtc traffic to and from it over forwarded ports from the host
+# These are the default ports. If the ports below are modified here you'll also need to set the ports in XML/Config.xml
+# for example <TurnServerPort>3478</TurnServerPort><TurnServerMinPort>50000</TurnServerMinPort><TurnServerMaxPort>50010</TurnServerMaxPort>
+# The main server port is overridden by creating a text file called port.txt in the root directory containing the port number, eg: 8090
+# To access the UI you must use the local IP address of the host, NOT localhost - for example http://192.168.1.12:8090/
+
+# Define default environment variables
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Main UI port
+EXPOSE 8090
+
+# TURN server port
+EXPOSE 3478/udp
+
+# TURN server UDP port range
+EXPOSE 50000-50010/udp
+
+# Data volumes
+VOLUME ["/agent/Media/XML", "/agent/Media/WebServerRoot/Media", "/agent/Commands"]
+
+# Define service entrypoint
+CMD ["dotnet", "/agent/Agent.dll"]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -1,5 +1,5 @@
 # Use MS maintained .net docker image wuith aspnet and core runtimes.
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.17-bionic-arm32v7
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.17-focal-arm32v7
 
 #Define download location variables
 ARG FILE_LOCATION="https://ispyfiles.azureedge.net/downloads/Agent_ARM32_3_4_3_0.zip"

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,73 @@
+# Use MS maintained .net docker image wuith aspnet and core runtimes.
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.10-bionic-arm64v8
+
+#Define download location variables
+ARG FILE_LOCATION="https://ispyfiles.azureedge.net/downloads/Agent_ARM64_3_4_3_0.zip"
+ENV FILE_LOCATION_SET=${FILE_LOCATION:+true}
+ENV DEFAULT_FILE_LOCATION="https://www.ispyconnect.com/api/Agent/DownloadLocation2?productID=24&is64=true&platform=Linux"
+ARG DEBIAN_FRONTEND=noninteractive 
+ARG TZ=America/Los_Angeles
+    
+
+# Download and install dependencies
+RUN apt-get update \
+    && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common \
+    && wget http://security.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb \
+    && wget http://fr.archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_arm64.deb \
+    && dpkg -i libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb \
+    && dpkg -i libjpeg8_8c-2ubuntu8_arm64.deb \
+    && rm libjpeg8_8c-2ubuntu8_arm64.deb \
+    && rm libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb
+
+# Install jonathon's ffmpeg
+RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
+    apt-get update && apt-get install -y ffmpeg
+
+# Download/Install iSpy Agent DVR: 
+# Check if we were given a specific version
+RUN if [ "${FILE_LOCATION_SET}" = "true" ]; then \
+    echo "Downloading from specific location: ${FILE_LOCATION}" && \
+    wget -c ${FILE_LOCATION} -O agent.zip; \
+    else \
+    #Get latest instead
+    echo "Downloading latest" && \
+    wget -c $(wget -qO- "https://www.ispyconnect.com/api/Agent/DownloadLocation2?productID=24&is64=true&platform=Linux" | tr -d '"') -O agent.zip; \
+    fi && \
+    unzip agent.zip -d /agent && \
+    rm agent.zip
+    
+# Install libgdiplus, used for smart detection
+RUN apt-get install -y libgdiplus
+    
+# Install Time Zone
+RUN apt-get install -y tzdata
+
+# Clean up
+RUN apt-get -y --purge remove unzip wget \ 
+    && apt autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker needs to run a TURN server to get webrtc traffic to and from it over forwarded ports from the host
+# These are the default ports. If the ports below are modified here you'll also need to set the ports in XML/Config.xml
+# for example <TurnServerPort>3478</TurnServerPort><TurnServerMinPort>50000</TurnServerMinPort><TurnServerMaxPort>50010</TurnServerMaxPort>
+# The main server port is overridden by creating a text file called port.txt in the root directory containing the port number, eg: 8090
+# To access the UI you must use the local IP address of the host, NOT localhost - for example http://192.168.1.12:8090/
+
+# Define default environment variables
+ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+# Main UI port
+EXPOSE 8090
+
+# TURN server port
+EXPOSE 3478/udp
+
+# TURN server UDP port range
+EXPOSE 50000-50010/udp
+
+# Data volumes
+VOLUME ["/agent/Media/XML", "/agent/Media/WebServerRoot/Media", "/agent/Commands"]
+
+# Define service entrypoint
+CMD ["dotnet", "/agent/Agent.dll"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,5 +1,6 @@
 # Use MS maintained .net docker image wuith aspnet and core runtimes.
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.10-bionic-arm64v8
+# switching to buster for GLIBC 2.28, required by libcvextern.so from AgentDVR latest
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.17-buster-slim-arm64v8
 
 #Define download location variables
 ARG FILE_LOCATION="https://ispyfiles.azureedge.net/downloads/Agent_ARM64_3_4_3_0.zip"
@@ -11,7 +12,7 @@ ARG TZ=America/Los_Angeles
 
 # Download and install dependencies
 RUN apt-get update \
-    && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common \
+    && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common gpg ffmpeg \
     && wget http://ports.ubuntu.com/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb \
     && wget http://ports.ubuntu.com/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_arm64.deb \
     && dpkg -i libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb \
@@ -20,8 +21,8 @@ RUN apt-get update \
     && rm libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb
 
 # Install jonathon's ffmpeg
-RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
-    apt-get update && apt-get install -y ffmpeg
+#RUN add-apt-repository -y ppa:jonathonf/ffmpeg-4 && \
+#    apt-get update && apt-get install -y ffmpeg
 
 # Download/Install iSpy Agent DVR: 
 # Check if we were given a specific version

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -12,8 +12,8 @@ ARG TZ=America/Los_Angeles
 # Download and install dependencies
 RUN apt-get update \
     && apt-get install -y wget libtbb-dev libc6-dev unzip multiarch-support gss-ntlmssp software-properties-common \
-    && wget http://security.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb \
-    && wget http://fr.archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_arm64.deb \
+    && wget http://ports.ubuntu.com/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb \
+    && wget http://ports.ubuntu.com/pool/main/libj/libjpeg8-empty/libjpeg8_8c-2ubuntu8_arm64.deb \
     && dpkg -i libjpeg-turbo8_1.5.2-0ubuntu5.18.04.4_arm64.deb \
     && dpkg -i libjpeg8_8c-2ubuntu8_arm64.deb \
     && rm libjpeg8_8c-2ubuntu8_arm64.deb \


### PR DESCRIPTION
I noted some stability issues on a banana pi m3 running Armbian 32 bit with AgentDVR (baremetal), and when I reported it to Support they asked me to try docker.

There doesn't appear to be arm32v7 or arm64v8 docker images.  Let's fix that.

I (briefly) tried auto-detecting the architecture in a single Dockerfile, but the build context switches gave me some headaches.  For the mean-time, then, I just threw the updated build into separate files.