### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,9 @@ RUN add-apt-repository -y ppa:savoury1/ffmpeg4 && \
 # Install Time Zone
 RUN apt-get install -y tzdata
 
+# Install curl, used for calling external webservices in Commands
+RUN apt-get install -y curl
+
 # Clean up
 RUN apt-get -y --purge remove unzip wget \ 
     && apt autoremove -y \


### PR DESCRIPTION
Evalute to add "curl" feature. 

With "curl" in a command would be possible to manage webservices call directly. At the current state I have to create proxy services and use "Call URL" (Actions) function... this is more complicated to mantain and it's time consuming.

Furthermore, "curl" allows you to overcome the current limitations of the very basic "Call URL" (Actions) implementation.